### PR TITLE
Code cleanup

### DIFF
--- a/website/mcapp.data/src/app/browse/authors/browse-author-controller.js
+++ b/website/mcapp.data/src/app/browse/authors/browse-author-controller.js
@@ -1,7 +1,7 @@
 export class BrowseAuthorsController {
   constructor(authors) {
     'ngInject';
-    console.dir(authors);
+    // console.dir(authors); // i suspect that this is an error  // eslint-disable-line no-console
     this.authors = authors;
     this.pageSize = 10;
 

--- a/website/mcapp.data/src/app/browse/browse-service.js
+++ b/website/mcapp.data/src/app/browse/browse-service.js
@@ -1,3 +1,4 @@
+/* global _:true */
 export class browseService {
   /*@ngInject*/
   constructor($state) {

--- a/website/mcapp.data/src/app/details/comment-directive.js
+++ b/website/mcapp.data/src/app/details/comment-directive.js
@@ -1,3 +1,4 @@
+/* global toastr:true */
 export function CommentDirective() {
   'ngInject';
 
@@ -37,7 +38,7 @@ class CommentController {
         this.comment= "";
       });
     }else{
-      toastr.warning("Please sign in to add comment");  // eslint-disable-line no-undef
+      toastr.warning("Please sign in to add comment");
     }
   }
 }

--- a/website/mcapp.data/src/app/details/comment-directive.js
+++ b/website/mcapp.data/src/app/details/comment-directive.js
@@ -32,12 +32,12 @@ class CommentController {
 
   addComment(){
     if (this.user) {
-      this.actionsService.addComment(this.comment, this.datasetId, this.user.id).then((res) => {
+      this.actionsService.addComment(this.comment, this.datasetId, this.user.id).then(() => {
         this.getActions();
         this.comment= "";
       });
     }else{
-      toastr.warning("Please sign in to add comment");
+      toastr.warning("Please sign in to add comment");  // eslint-disable-line no-undef
     }
   }
 }

--- a/website/mcapp.data/src/app/details/details-controller.js
+++ b/website/mcapp.data/src/app/details/details-controller.js
@@ -1,3 +1,4 @@
+/* global _:true */
 export class DetailsController {
     /*@ngInject*/
     constructor(dataset, actionsService, toastr, userService, $uibModal, $previousState) {

--- a/website/mcapp.data/src/app/details/details-controller.js
+++ b/website/mcapp.data/src/app/details/details-controller.js
@@ -21,7 +21,7 @@ export class DetailsController {
     appreciate() {
         if (this.user) {
             this.dataset.appreciate = !this.dataset.appreciate;
-            this.actionsService.appreciate(this.dataset.id, this.user.id).then((res) => {
+            this.actionsService.appreciate(this.dataset.id, this.user.id).then(() => {
                 this.getActions();
             });
         } else {
@@ -32,7 +32,7 @@ export class DetailsController {
 
     removeAppreciate() {
         if (this.user) {
-            this.actionsService.removeAppreciation(this.dataset.id, this.user.id).then((res) => {
+            this.actionsService.removeAppreciation(this.dataset.id, this.user.id).then(() => {
                 this.dataset.appreciate = false;
                 this.getActions();
             });
@@ -71,7 +71,8 @@ export class DetailsController {
     }
 
     openImage(file) {
-        var modalInstance = this.$uibModal.open({
+        // var modalInstance =  // this var not used
+        this.$uibModal.open({
             animation: true,
             templateUrl: 'app/details/pop-up.html',
             controller: 'PopUpController',

--- a/website/mcapp.data/src/app/details/mcpub-dataset-details-otherds.directive.js
+++ b/website/mcapp.data/src/app/details/mcpub-dataset-details-otherds.directive.js
@@ -5,7 +5,7 @@ export function DatasetDetailsOtherdsDirective() {
     restrict: 'E',
     templateUrl: 'app/details/mcpub-dataset-details-otherds.html',
     scope: {
-      dataset: "=",
+      dataset: "="
     },
     controller: DatasetDetailsOtherdsController,
     controllerAs: 'ctrl',

--- a/website/mcapp.data/src/app/details/mcpub-dataset-details-summary.directive.js
+++ b/website/mcapp.data/src/app/details/mcpub-dataset-details-summary.directive.js
@@ -5,7 +5,7 @@ export function DatasetDetailsSummaryDirective() {
     restrict: 'E',
     templateUrl: 'app/details/mcpub-dataset-details-summary.html',
     scope: {
-      dataset: "=",
+      dataset: "="
     },
   controller: DatasetDetailsSummaryController,
     controllerAs: 'ctrl',
@@ -28,7 +28,7 @@ class DatasetDetailsSummaryController {
   appreciate() {
     if (this.user) {
       this.dataset.appreciate = !this.dataset.appreciate;
-      this.actionsService.appreciate(this.dataset.id, this.user.id).then((res) => {
+      this.actionsService.appreciate(this.dataset.id, this.user.id).then(() => {
         this.getActions();
       });
     } else {
@@ -39,7 +39,7 @@ class DatasetDetailsSummaryController {
 
   removeAppreciate() {
     if (this.user) {
-      this.actionsService.removeAppreciation(this.dataset.id, this.user.id).then((res) => {
+      this.actionsService.removeAppreciation(this.dataset.id, this.user.id).then(() => {
         this.dataset.appreciate = false;
         this.getActions();
       });

--- a/website/mcapp.data/src/app/details/mcpub-dataset-details-votes.component.js
+++ b/website/mcapp.data/src/app/details/mcpub-dataset-details-votes.component.js
@@ -19,7 +19,7 @@ export class DatasetDetailsVotesController {
     appreciate() {
         if (this.user) {
             this.dataset.appreciate = !this.dataset.appreciate;
-            this.actionsService.appreciate(this.dataset.id, this.user.id).then((res) => {
+            this.actionsService.appreciate(this.dataset.id, this.user.id).then(() => {
                 this.getActions();
             });
         } else {
@@ -30,7 +30,7 @@ export class DatasetDetailsVotesController {
 
     removeAppreciate() {
         if (this.user) {
-            this.actionsService.removeAppreciation(this.dataset.id, this.user.id).then((res) => {
+            this.actionsService.removeAppreciation(this.dataset.id, this.user.id).then(() => {
                 this.dataset.appreciate = false;
                 this.getActions();
             });
@@ -42,7 +42,7 @@ export class DatasetDetailsVotesController {
 
     addTag(params) {
         this.actionsService.addTag(this.dataset.id, this.user.id, params.id).then(
-            (tag) => this.dataset.tags = _.sortBy(this.dataset.tags, "id")
+            () => this.dataset.tags = _.sortBy(this.dataset.tags, "id")
         );
     }
 

--- a/website/mcapp.data/src/app/details/mcpub-dataset-details-votes.component.js
+++ b/website/mcapp.data/src/app/details/mcpub-dataset-details-votes.component.js
@@ -1,3 +1,4 @@
+/* global _:true */
 export class DatasetDetailsVotesController {
 
     constructor(userService, actionsService, toastr) {

--- a/website/mcapp.data/src/app/details/outline/mcpub-dataset-details-outline.component.js
+++ b/website/mcapp.data/src/app/details/outline/mcpub-dataset-details-outline.component.js
@@ -1,3 +1,4 @@
+/* global _:true */
 export class DatasetDetailsOutlineController {
     constructor() {
         'ngInject';

--- a/website/mcapp.data/src/app/details/outline/mcpub-dataset-details-outline.component.js
+++ b/website/mcapp.data/src/app/details/outline/mcpub-dataset-details-outline.component.js
@@ -7,7 +7,7 @@ export class DatasetDetailsOutlineController {
     }
 
     $onInit() {
-        let treeModel = new TreeModel();
+        let treeModel = new TreeModel();  // eslint-disable-line no-undef
         this.root = treeModel.parse({id: 1, children: []});
         this.rootNode = this.root.first(node => node.model.id === 1);
         let sample2InputProcesses = {};
@@ -35,7 +35,7 @@ export class DatasetDetailsOutlineController {
         // Go through each node that has been added in the tree adding its immediate children.
         // Keep looping over newly added nodes until no more are added.
         let newlyAdded = [];
-        while (true) {
+        while (true) {  // eslint-disable-line no-constant-condition
             addedIds.forEach(id => {
                 let n = this.root.first(node => node.model.id === id);
                 n.model.output_samples.forEach(s => {

--- a/website/mcapp.data/src/app/filters/to-date-string-filter.js
+++ b/website/mcapp.data/src/app/filters/to-date-string-filter.js
@@ -2,19 +2,14 @@ export function toDateStringFilter() {
   return function(input) {
     if (input) {
       var t = input;
-      var type = typeof t;
-      if (type === 'string') {
+      if (angular.isString(t)) {
         return new Date(t).toDateString();
       }
-      if (type === 'Date') {
-        return t.toDateString();
+      if (angular.isNumber(t)) {
+        new Date(t * 1000).toDateString();
       }
-      var date = null;
-      try {
-        date = new Date(t * 1000);
-      } catch (ignore) {}
-      if (date) {
-        return date.toDateString();
+      if (angular.isObject(t) && (t instanceof Date)) {
+        return t.toDateString();
       }
       return "";
     }

--- a/website/mcapp.data/src/app/home/home.controller.js
+++ b/website/mcapp.data/src/app/home/home.controller.js
@@ -1,3 +1,4 @@
+/* global _:true */
 export class HomeController {
   constructor(tags, count_authors, count_datasets, browseService, $state, userService) {
     'ngInject';

--- a/website/mcapp.data/src/app/index.run.js
+++ b/website/mcapp.data/src/app/index.run.js
@@ -6,7 +6,7 @@ export function runBlock($log, userService, $state, $rootScope, Restangular) {
         Restangular.setDefaultRequestParams(['get', 'post'], {apikey: userService.apikey()});
     }
 
-    $rootScope.$on('$stateChangeStart', function(event, toState) {
+    $rootScope.$on('$stateChangeStart', function(event, toState) {  // eslint-disable-line angular/on-watch
         $rootScope.email = userService.email();
         //$rootScope.image = userService.image();
         // search bar under the top navigation will show up only for certain routes

--- a/website/mcapp.data/src/app/search/search-service.js
+++ b/website/mcapp.data/src/app/search/search-service.js
@@ -1,3 +1,4 @@
+/* global _:true */
 export class searchService {
     /*@ngInject*/
     constructor(Restangular, $filter) {

--- a/website/mcapp.data/src/app/services/actions-service.js
+++ b/website/mcapp.data/src/app/services/actions-service.js
@@ -34,7 +34,7 @@ export class actionsService {
             message: msg,
             user_id: user_id,
             dataset_id: dataset_id
-        }).then((result)=> {
+        }).then(()=> {
             this.toastr.success("Your comment has been registered");
         });
     }
@@ -46,7 +46,7 @@ export class actionsService {
             tag: tag
         }).then(
             result => result,
-            (error) => {
+            () => {
                 this.toastr.warning("Duplicate request");
             });
     }

--- a/website/mcapp.data/src/app/services/user-service.js
+++ b/website/mcapp.data/src/app/services/user-service.js
@@ -9,9 +9,9 @@ export class userService {
 
         if (this.$window.sessionStorage.mcuser) {
             try {
-                this.mcuser = JSON.parse($window.sessionStorage.mcuser);
+                this.mcuser = angular.fromJSON($window.sessionStorage.mcuser);
             } catch (err) {
-                console.log("Error parsing mcuser in sessionStorage");
+                $log.log.error("Error parsing mcuser in sessionStorage");
                 this.mcuser = null;
             }
         }

--- a/website/mcapp.data/src/app/services/user-service.js
+++ b/website/mcapp.data/src/app/services/user-service.js
@@ -11,7 +11,6 @@ export class userService {
             try {
                 this.mcuser = angular.fromJSON($window.sessionStorage.mcuser);
             } catch (err) {
-                $log.log.error("Error parsing mcuser in sessionStorage");
                 this.mcuser = null;
             }
         }
@@ -59,7 +58,7 @@ export class userService {
 
         modalInstance.result.then(
             ()=> null,
-            () =>this.$log.info('Modal dismissed at : ' + new Date())
+            ()=>this.$log.info('Modal dismissed at : ' + new Date())
         );
     }
 }

--- a/website/mcapp.projects/src/app/global.components/graph/mc-processes-graph.component.js
+++ b/website/mcapp.projects/src/app/global.components/graph/mc-processes-graph.component.js
@@ -1,3 +1,4 @@
+/* global cytoscape:true */
 class MCProcessesGraphComponentController {
     /*@ngInject*/
     constructor(experimentsService, processesService, templates, $stateParams, toast, $mdDialog, $timeout) {
@@ -117,11 +118,8 @@ class MCProcessesGraphComponentController {
         // any local layout that the user has created. Hence, this needs to be
         // updated so that only the process is deleted, and the node is deleted
         // from the graph without disturding the layout. Terry Weymouth - Sept 29, 2016
-//        console.log("Deleting process: " + this.selectedProcess.id,this.projectId);
         this.processesService.deleteProcess(this.projectId,this.selectedProcess.id)
-            .then(ret => {
-//                    console.log("deleteNodeAndProcess - return:",ret);
-
+            .then(() => {
                     this.experimentsService.getProcessesForExperiment(this.projectId, this.experimentId)
                         .then(
                             (processes) => {
@@ -140,7 +138,6 @@ class MCProcessesGraphComponentController {
     }
 
     allProcessesGraph() {
-//        console.log("all graph");
         let sample2InputProcesses = {};
         let sample2OutputProcesses = {};
 
@@ -337,8 +334,10 @@ class MCProcessesGraphComponentController {
         console.log('sampleTransformationGraph');
     }
 
-    filterOnSample(sample) {
-        //console.log('filterOnSample', sample);
+    filterOnSample(
+        // sample // not used
+    ) {
+        // console.log('filterOnSample', sample);
         let matches = [];
         this.cy.nodes().forEach(node => {
             console.log(node.data('id'));

--- a/website/mcapp.projects/src/app/global.components/graph/outline/mc-process-graph-outline.component.js
+++ b/website/mcapp.projects/src/app/global.components/graph/outline/mc-process-graph-outline.component.js
@@ -32,7 +32,7 @@ class MCProcessGraphOutlineComponentController {
         // Go through each node that has been added in the tree adding its immediate children.
         // Keep looping over newly added nodes until no more are added.
         let newlyAdded = [];
-        while (true) {
+        while (true) {  // eslint-disable-line no-constant-condition
             addedIds.forEach(id => {
                 let n = this.root.first(node => node.model.id === id);
                 n.model.output_samples.forEach(s => {

--- a/website/mcapp.projects/src/app/global.services/templates.service.js
+++ b/website/mcapp.projects/src/app/global.services/templates.service.js
@@ -4,9 +4,10 @@ export function templatesService($filter, processEdit, $log) {
     var self = this;
     self.templates = {};
 
-    function createName(templateName) {
-        return templateName + ' - ' + $filter('date')(new Date(), 'MM/dd/yyyy @ h:mma');
-    }
+    // defined but not used
+    //function createName(templateName) {
+    //    return templateName + ' - ' + $filter('date')(new Date(), 'MM/dd/yyyy @ h:mma');
+    //}
 
     function getTemplate(name) {
         var t = _.find(self.templates, {name: name});

--- a/website/mcapp.projects/src/app/projects/components/mc-project-share-tree.component.js
+++ b/website/mcapp.projects/src/app/projects/components/mc-project-share-tree.component.js
@@ -28,12 +28,12 @@ function MCProjectShareTreeComponentController(projectTreeService) {
     ctrl.nodropEnabled = false;
 
     ctrl.treeOptions = {
-        dragStart: function(event) {
+        dragStart: function() {
             ctrl.nodropEnabled = true;
             return true;
         },
 
-        beforeDrop: function(event) {
+        beforeDrop: function() {
             ctrl.nodropEnabled = false;
             return true;
         }

--- a/website/mcapp.projects/src/app/routes.js
+++ b/website/mcapp.projects/src/app/routes.js
@@ -213,7 +213,13 @@ export function setupRoutes($stateProvider, $urlRouterProvider) {
         .state('project.experiment.publish', {
             url: '/publish',
             template: '<mc-experiment-publish></mc-experiment-publish>'
-        })
+        });
+
+    // Not sure why, but the following generates an error in eslint:
+    // should use controllerAs syntax  angular/controller-as-route
+    // fixed (superficially) with the following -
+    /* eslint-disable angular/controller-as-route*/
+    $stateProvider
         .state('project.experiment.datasets', {
             url: '/datasets',
             template: '<div ui-view></div>',
@@ -222,7 +228,10 @@ export function setupRoutes($stateProvider, $urlRouterProvider) {
                     $state.go('project.experiment.datasets.list');
                 }
             }]
-        })
+        });
+    /* eslint-enable angular/controller-as-route*/
+
+    $stateProvider
         .state('project.experiment.datasets.list', {
             url: '/list',
             template: '<mc-experiment-datasets></mc-experiment-datasets>'


### PR DESCRIPTION
fixed all lint errors (and a few code cleanup actions) by either removing unused arguments or by suppressing eslint errors (e.g. with '// eslint-disable-line')