### PR TITLE
Fix process delete

### DIFF
--- a/backend/servers/mcapi/db/model/experiment-delete.js
+++ b/backend/servers/mcapi/db/model/experiment-delete.js
@@ -302,6 +302,6 @@ function* clearAllRemainingLinks(experimentId) {
     for (let i = 0; i < tables.length; i++) {
         let table = tables[i];
         let list = yield r.table(table)
-            .getAll(experimentId,{index: 'experiment_id'}).delete();
+            .getAll(experimentId, {index: 'experiment_id'}).delete();
     }
 }

--- a/backend/servers/mcapi/db/model/experiment-delete.js
+++ b/backend/servers/mcapi/db/model/experiment-delete.js
@@ -150,7 +150,7 @@ function* deleteProcessesSamplesSetupAndMeasure(projectId, experimentId, dryRun)
         }
         idList.push(process.id);
         if (!dryRun) {
-            yield processes.deleteProcess(projectId, process.id);
+            yield processes.deleteProcess(projectId, process.id, {'force': true});
         }
     }
 

--- a/backend/servers/mcapi/db/model/processes.js
+++ b/backend/servers/mcapi/db/model/processes.js
@@ -181,7 +181,7 @@ function* deleteProcess(projectId, processId, options) {
         return {error: error};
     }
 
-    return {val: "Process Deleted"};
+    return {val: {action: 'deleted', id: processId}};
 }
 
 function* createProcessTemplate(template, owner) {

--- a/backend/servers/mcapi/db/model/processes.js
+++ b/backend/servers/mcapi/db/model/processes.js
@@ -76,6 +76,32 @@ function* datasetsForProcess(processId) {
 function* deleteProcess(projectId, processId) {
     let i;
 
+    // can not delete a process that is in a dataset
+    let dataset2process = yield r.table('dataset2process').getAll(processId,{index:'process_id'});
+    if (dataset2process.length > 0) {
+        return {error: "Can not delete a process that is in a dataset: remove process from dataset(s)"}
+    }
+
+    // can not delete a process that is a non-leaf node in a workflow;
+    // a process a non-leaf node if it has any 'out' sample that is an 'in' sample elsewhere
+    let joinRecords = yield r.table('process2sample').getAll(processId,{index: 'process_id'})
+        .eqJoin('sample_id',r.db('materialscommons').table('process2sample'),{index:'sample_id'})
+        .map({
+            "p1": r.row("left")("process_id"),
+            "d1": r.row("left")("direction"),
+            "p2": r.row("right")("process_id"),
+            "d2": r.row("right")("direction"),
+            "sample_id" : r.row("right")("sample_id")
+        }).filter({'d1':'out'}).filter({'d2':'in'});
+    for (i = 0; i < joinRecords.length; i++) {
+        let record = joinRecords[i];
+        if (record.p1 != record.p2) {
+            return {error: "Can not delete a process, "
+                + processId
+                + ", that is not the leaf node of a workflow; delete other processes first"}
+        }
+    }
+
     try {
         // remove project2process records with projectId, and processId
         yield r.table('project2process').getAll([projectId, processId], {index: 'project_process'}).delete();

--- a/backend/servers/mcapi/db/model/processes.js
+++ b/backend/servers/mcapi/db/model/processes.js
@@ -73,32 +73,39 @@ function* datasetsForProcess(processId) {
     return yield r.expr(datasetIdValues).map(r.db('materialscommons').table('datasets').get(r.row)).coerceTo('array');
 }
 
-function* deleteProcess(projectId, processId) {
+function* deleteProcess(projectId, processId, options) {
+    let forceDelete = false;
+    if (options && options.force) forceDelete = true;
+
     let i;
 
-    // can not delete a process that is in a dataset
-    let dataset2process = yield r.table('dataset2process').getAll(processId,{index:'process_id'});
-    if (dataset2process.length > 0) {
-        return {error: "Can not delete a process that is in a dataset: remove process from dataset(s)"}
-    }
+    if (!forceDelete) {
+        // can not delete a process that is in a dataset
+        let dataset2process = yield r.table('dataset2process').getAll(processId, {index: 'process_id'});
+        if (dataset2process.length > 0) {
+            return {error: "Can not delete a process that is in a dataset: remove process from dataset(s)"}
+        }
 
-    // can not delete a process that is a non-leaf node in a workflow;
-    // a process a non-leaf node if it has any 'out' sample that is an 'in' sample elsewhere
-    let joinRecords = yield r.table('process2sample').getAll(processId,{index: 'process_id'})
-        .eqJoin('sample_id',r.db('materialscommons').table('process2sample'),{index:'sample_id'})
-        .map({
-            "p1": r.row("left")("process_id"),
-            "d1": r.row("left")("direction"),
-            "p2": r.row("right")("process_id"),
-            "d2": r.row("right")("direction"),
-            "sample_id" : r.row("right")("sample_id")
-        }).filter({'d1':'out'}).filter({'d2':'in'});
-    for (i = 0; i < joinRecords.length; i++) {
-        let record = joinRecords[i];
-        if (record.p1 != record.p2) {
-            return {error: "Can not delete a process, "
-                + processId
-                + ", that is not the leaf node of a workflow; delete other processes first"}
+        // can not delete a process that is a non-leaf node in a workflow;
+        // a process a non-leaf node if it has any 'out' sample that is an 'in' sample elsewhere
+        let joinRecords = yield r.table('process2sample').getAll(processId, {index: 'process_id'})
+            .eqJoin('sample_id', r.db('materialscommons').table('process2sample'), {index: 'sample_id'})
+            .map({
+                "p1": r.row("left")("process_id"),
+                "d1": r.row("left")("direction"),
+                "p2": r.row("right")("process_id"),
+                "d2": r.row("right")("direction"),
+                "sample_id": r.row("right")("sample_id")
+            }).filter({'d1': 'out'}).filter({'d2': 'in'});
+        for (i = 0; i < joinRecords.length; i++) {
+            let record = joinRecords[i];
+            if (record.p1 != record.p2) {
+                return {
+                    error: "Can not delete a process, "
+                    + processId
+                    + ", that is not the leaf node of a workflow; delete other processes first"
+                }
+            }
         }
     }
 

--- a/backend/tests/mcapi/Database-Level/specs/experiments-delete-experiment-notes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/experiments-delete-experiment-notes-spec.js
@@ -77,8 +77,9 @@ before(function*() {
     assert.equal(updated_project.id,projectId);
     project = updated_project;
 
-    for (let i = 0; i < process_list.length; i++) {
-        let process = process_list[i];
+    for (let i = process_list.length; i > 0; i--) {
+        // delete leaf-nodes first!
+        let process = process_list[i-1];
         yield processes.deleteProcess(project.id,process.id);
     }
 

--- a/backend/tests/mcapi/Database-Level/specs/experiments-delete-experiment-notes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/experiments-delete-experiment-notes-spec.js
@@ -79,8 +79,8 @@ before(function*() {
 
     for (let i = process_list.length; i > 0; i--) {
         // delete leaf-nodes first!
-        let process = process_list[i-1];
-        yield processes.deleteProcess(project.id,process.id);
+        let process = process_list[i - 1];
+        yield processes.deleteProcess(project.id, process.id);
     }
 
     let simple = true;

--- a/backend/tests/mcapi/Database-Level/specs/experiments-delete-processes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/experiments-delete-processes-spec.js
@@ -149,8 +149,9 @@ describe('Feature - Experiments: ', function() {
             assert.isOk(dataset_list);
             assert.equal(dataset_list.length,0);
 
-            for (let i = 0; i < process_list.length; i++) {
-                let process = process_list[i];
+            for (let i = process_list.length; i > 0; i--) {
+                // delete leaf-nodes first!
+                let process = process_list[i-1];
                 yield processes.deleteProcess(project.id,process.id);
             }
 

--- a/backend/tests/mcapi/Database-Level/specs/experiments-delete-processes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/experiments-delete-processes-spec.js
@@ -28,8 +28,8 @@ const buildDemoProject = require(build_project_base + '/build-demo-project');
 
 const base_project_name = "Test directory";
 
-let random_name = function(){
-    let number = Math.floor(Math.random()*10000);
+let random_name = function () {
+    let number = Math.floor(Math.random() * 10000);
     return base_project_name + number;
 };
 
@@ -47,9 +47,9 @@ before(function*() {
 
     let user = yield dbModelUsers.getUser(userId);
     assert.isOk(user, "No test user available = " + userId);
-    assert.equal(userId,user.id);
+    assert.equal(userId, user.id);
 
-    let valOrError = yield buildDemoProject.findOrBuildAllParts(user,demoProjectConf.datapathPrefix);
+    let valOrError = yield buildDemoProject.findOrBuildAllParts(user, demoProjectConf.datapathPrefix);
     assert.isUndefined(valOrError.error, "Unexpected error from createDemoProjectForUser: " + valOrError.error);
     let results = valOrError.val;
     project = results.project;
@@ -72,7 +72,7 @@ before(function*() {
     assert.equal(updated_project.owner, userId);
     assert.equal(updated_project.name, name);
     assert.equal(updated_project.description, description);
-    assert.equal(updated_project.id,project_id);
+    assert.equal(updated_project.id, project_id);
     project = updated_project;
 
     let processesToAdd = [
@@ -82,8 +82,8 @@ before(function*() {
     let processesToDelete = [];
 
     let datasetArgs = {
-        title:"Test Dataset1",
-        description:"Dataset for testing"
+        title: "Test Dataset1",
+        description: "Dataset for testing"
     };
 
     let result = yield experimentDatasets.createDatasetForExperiment(experiment_id, userId, datasetArgs);
@@ -93,8 +93,8 @@ before(function*() {
     yield experimentDatasets.updateProcessesInDataset(dataset.id, processesToAdd, processesToDelete);
 
     datasetArgs = {
-        title:"Test Dataset2",
-        description:"Dataset for testing"
+        title: "Test Dataset2",
+        description: "Dataset for testing"
     };
 
     result = yield experimentDatasets.createDatasetForExperiment(experiment_id, userId, datasetArgs);
@@ -106,27 +106,27 @@ before(function*() {
     results = yield experimentDatasets.getDatasetsForExperiment(experiment_id);
     let dataset_list = results.val;
     assert.isOk(dataset_list);
-    assert.equal(dataset_list.length,2);
+    assert.equal(dataset_list.length, 2);
 
 });
 
-describe('Feature - Experiments: ', function() {
+describe('Feature - Experiments: ', function () {
     describe('Delete Experiment - in parts: ', function () {
-        it('deletes datasets and deletes all processes and samples', function* (){
+        it('deletes datasets and deletes all processes and samples', function*() {
             let project_id = project.id;
             assert.isOk(project_id);
             let experiment_id = experiment.id;
             assert.isOk(experiment_id);
 
             // Note: create fake sample that is not part of a process for testing
-            let rv = yield r.table('samples').insert({'name':'fake sample', 'otype':'sample', 'owner':'noone'})
+            let rv = yield r.table('samples').insert({'name': 'fake sample', 'otype': 'sample', 'owner': 'noone'})
             let key = rv.generated_keys[0];
             yield r.table('experiment2sample').insert({sample_id: key, experiment_id: experiment_id});
 
             let results = yield experimentDatasets.getDatasetsForExperiment(experiment_id);
             let dataset_list = results.val;
             assert.isOk(dataset_list);
-            assert.equal(dataset_list.length,2);
+            assert.equal(dataset_list.length, 2);
 
             let hasPublishedDatasets = false;
             for (let i = 0; i < dataset_list.length; i++) {
@@ -147,25 +147,25 @@ describe('Feature - Experiments: ', function() {
             results = yield experimentDatasets.getDatasetsForExperiment(experiment_id);
             dataset_list = results.val;
             assert.isOk(dataset_list);
-            assert.equal(dataset_list.length,0);
+            assert.equal(dataset_list.length, 0);
 
             for (let i = process_list.length; i > 0; i--) {
                 // delete leaf-nodes first!
-                let process = process_list[i-1];
-                yield processes.deleteProcess(project.id,process.id);
+                let process = process_list[i - 1];
+                yield processes.deleteProcess(project.id, process.id);
             }
 
             let simple = true;
             results = yield experiments.getProcessesForExperiment(experiment_id, simple);
             let proc_list = results.val;
             assert.isOk(proc_list);
-            assert.equal(proc_list.length,0);
+            assert.equal(proc_list.length, 0);
 
             // ... but, in rare cases, there my be samples in the experiment that are in no process
 
             let sampleList = yield r.table('experiment2sample')
-                .getAll(experiment_id,{index:'experiment_id'})
-                .eqJoin('sample_id',r.table('samples')).zip()
+                .getAll(experiment_id, {index: 'experiment_id'})
+                .eqJoin('sample_id', r.table('samples')).zip()
                 .getField('sample_id');
 
             rv = yield r.table('samples').getAll(r.args([...sampleList])).delete();
@@ -175,7 +175,7 @@ describe('Feature - Experiments: ', function() {
             // and the sample entries for the experiment are left in experiment2sample
 
             rv = yield r.table('experiment2sample')
-                .getAll(experiment_id,{index:'experiment_id'}).delete();
+                .getAll(experiment_id, {index: 'experiment_id'}).delete();
 
             assert.equal(rv.deleted, 8);
 

--- a/backend/tests/mcapi/Database-Level/specs/processes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/processes-spec.js
@@ -39,7 +39,6 @@ before(function*() {
     assert.isOk(ret.val);
     project = ret.val;
     assert.equal(project.owner,user.id);
-    console.log("Test project name: ",project.name);
 });
 
 describe('Feature - Processes: ', function() {

--- a/backend/tests/mcapi/Database-Level/specs/processes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/processes-spec.js
@@ -25,8 +25,8 @@ let user = null;
 let project = null;
 let experiment_number = 0;
 
-let random_project_name = function(){
-    let number = Math.floor(Math.random()*10000);
+let random_project_name = function () {
+    let number = Math.floor(Math.random() * 10000);
     return "Project For Process Testing - " + number;
 };
 
@@ -34,103 +34,103 @@ before(function*() {
     user = yield dbModelUsers.getUser(userId);
     assert.isOk(user, "No test user available = " + userId);
     assert.equal(userId, user.id);
-    let ret = yield testHelpers.createProject(random_project_name(),user);
+    let ret = yield testHelpers.createProject(random_project_name(), user);
     assert.isOk(ret);
     assert.isOk(ret.val);
     project = ret.val;
-    assert.equal(project.owner,user.id);
+    assert.equal(project.owner, user.id);
 });
 
-describe('Feature - Processes: ', function() {
+describe('Feature - Processes: ', function () {
     describe('Function level', function () {
-        it('creates a process', function*(){
-            let ret = yield testHelpers.createExperiment(project,"Create Process Experiment");
+        it('creates a process', function*() {
+            let ret = yield testHelpers.createExperiment(project, "Create Process Experiment");
             assert.isOk(ret);
             assert.isOk(ret.val);
             let experiment = ret.val;
             assert.isOk(experiment);
-            assert.equal(experiment.owner,user.id);
+            assert.equal(experiment.owner, user.id);
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_Create Samples');
+                project, experiment, "Test Create Sample Process", 'global_Create Samples');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let process = ret.val;
             assert.isOk(process);
-            assert.equal(process.owner,user.id);
+            assert.equal(process.owner, user.id);
         });
-        it('creates two processes linked by sample ', function*(){
-            let ret = yield testHelpers.createExperiment(project,"Two Processes Experiment");
+        it('creates two processes linked by sample ', function*() {
+            let ret = yield testHelpers.createExperiment(project, "Two Processes Experiment");
             assert.isOk(ret);
             assert.isOk(ret.val);
             let experiment = ret.val;
             assert.isOk(experiment);
-            assert.equal(experiment.owner,user.id);
+            assert.equal(experiment.owner, user.id);
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_Create Samples');
+                project, experiment, "Test Create Sample Process", 'global_Create Samples');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let create_sample_process = ret.val;
             assert.isOk(create_sample_process);
-            assert.equal(create_sample_process.owner,user.id);
+            assert.equal(create_sample_process.owner, user.id);
             ret = yield testHelpers.createSamples(
                 project, experiment, create_sample_process, ['Test Sample']
             );
             assert.isOk(ret);
             assert.isOk(ret.val);
             assert.isOk(ret.val.samples);
-            assert.equal(ret.val.samples.length,1);
+            assert.equal(ret.val.samples.length, 1);
             let sample = ret.val.samples[0];
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_SEM');
+                project, experiment, "Test Create Sample Process", 'global_SEM');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let measurement_process = ret.val;
             assert.isOk(measurement_process);
-            assert.equal(measurement_process.owner,user.id);
+            assert.equal(measurement_process.owner, user.id);
             ret = yield testHelpers.addSamplesToProcess(
                 project, experiment, measurement_process, [sample]
             );
             assert.isOk(ret);
             assert.isOk(ret.val);
-            assert.equal(ret.val.owner,user.id);
-            assert.equal(ret.val.id,measurement_process.id);
+            assert.equal(ret.val.owner, user.id);
+            assert.equal(ret.val.id, measurement_process.id);
         });
-        it('deletes two processes leaf first', function*(){
-            let ret = yield testHelpers.createExperiment(project,"Two Processes Delete Experiment");
+        it('deletes two processes leaf first', function*() {
+            let ret = yield testHelpers.createExperiment(project, "Two Processes Delete Experiment");
             assert.isOk(ret);
             assert.isOk(ret.val);
             let experiment = ret.val;
             assert.isOk(experiment);
-            assert.equal(experiment.owner,user.id);
+            assert.equal(experiment.owner, user.id);
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_Create Samples');
+                project, experiment, "Test Create Sample Process", 'global_Create Samples');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let create_sample_process = ret.val;
             assert.isOk(create_sample_process);
-            assert.equal(create_sample_process.owner,user.id);
+            assert.equal(create_sample_process.owner, user.id);
             ret = yield testHelpers.createSamples(
                 project, experiment, create_sample_process, ['Test Sample']
             );
             assert.isOk(ret);
             assert.isOk(ret.val);
             assert.isOk(ret.val.samples);
-            assert.equal(ret.val.samples.length,1);
+            assert.equal(ret.val.samples.length, 1);
             let sample = ret.val.samples[0];
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_SEM');
+                project, experiment, "Test Create Sample Process", 'global_SEM');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let measurement_process = ret.val;
             assert.isOk(measurement_process);
-            assert.equal(measurement_process.owner,user.id);
+            assert.equal(measurement_process.owner, user.id);
             ret = yield testHelpers.addSamplesToProcess(
                 project, experiment, measurement_process, [sample]
             );
             assert.isOk(ret);
             assert.isOk(ret.val);
-            assert.equal(ret.val.owner,user.id);
-            assert.equal(ret.val.id,measurement_process.id);
+            assert.equal(ret.val.owner, user.id);
+            assert.equal(ret.val.id, measurement_process.id);
             ret = yield processes.deleteProcess(project.id, measurement_process.id);
             assert.isOk(ret);
             assert.isOk(ret.val);
@@ -138,42 +138,42 @@ describe('Feature - Processes: ', function() {
             assert.isOk(ret);
             assert.isOk(ret.val);
         });
-        it('does not allow deleting non-leaf nodes', function*(){
-            let ret = yield testHelpers.createExperiment(project,"Two Processes Delete Experiment");
+        it('does not allow deleting non-leaf nodes', function*() {
+            let ret = yield testHelpers.createExperiment(project, "Two Processes Delete Experiment");
             assert.isOk(ret);
             assert.isOk(ret.val);
             let experiment = ret.val;
             assert.isOk(experiment);
-            assert.equal(experiment.owner,user.id);
+            assert.equal(experiment.owner, user.id);
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_Create Samples');
+                project, experiment, "Test Create Sample Process", 'global_Create Samples');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let create_sample_process = ret.val;
             assert.isOk(create_sample_process);
-            assert.equal(create_sample_process.owner,user.id);
+            assert.equal(create_sample_process.owner, user.id);
             ret = yield testHelpers.createSamples(
                 project, experiment, create_sample_process, ['Test Sample']
             );
             assert.isOk(ret);
             assert.isOk(ret.val);
             assert.isOk(ret.val.samples);
-            assert.equal(ret.val.samples.length,1);
+            assert.equal(ret.val.samples.length, 1);
             let sample = ret.val.samples[0];
             ret = yield testHelpers.createProcess(
-                project, experiment, "Test Create Sample Process",'global_SEM');
+                project, experiment, "Test Create Sample Process", 'global_SEM');
             assert.isOk(ret);
             assert.isOk(ret.val);
             let measurement_process = ret.val;
             assert.isOk(measurement_process);
-            assert.equal(measurement_process.owner,user.id);
+            assert.equal(measurement_process.owner, user.id);
             ret = yield testHelpers.addSamplesToProcess(
                 project, experiment, measurement_process, [sample]
             );
             assert.isOk(ret);
             assert.isOk(ret.val);
-            assert.equal(ret.val.owner,user.id);
-            assert.equal(ret.val.id,measurement_process.id);
+            assert.equal(ret.val.owner, user.id);
+            assert.equal(ret.val.id, measurement_process.id);
             ret = yield processes.deleteProcess(project.id, create_sample_process.id);
             assert.isOk(ret);
             assert.isOk(ret.error);

--- a/backend/tests/mcapi/Database-Level/specs/processes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/processes-spec.js
@@ -1,72 +1,87 @@
 'use strict';
-require('mocha');
+
+const it = require('mocha').it;
 require('co-mocha');
+const _ = require('lodash');
 const chai = require('chai');
-const assert = require('chai').assert;
+const assert = chai.assert;
 
 const r = require('rethinkdbdash')({
     db: process.env.MCDB || 'materialscommons',
     port: process.env.MCDB_PORT || 30815
 });
 
-const backend_base = '../../../..';
-const dbModelUsers = require(backend_base + '/servers/mcapi/db/model/users');
-const projects = require(backend_base + '/servers/mcapi/db/model/projects');
-const directories = require(backend_base + '/servers/mcapi/db/model/directories');
+const mcapi_base = '../../../../servers/mcapi';
+const backend_base = mcapi_base + "/db/model";
 
-const base_user_id = 'thisIsAUserForTestingONLY!';
-const fullname = "Test User";
-const base_project_name = "Test project - test 1: ";
+const dbModelUsers = require(backend_base + '/users');
 
-let random_name = function(){
+const testHelpers = require('./test-helpers');
+
+let userId = "test@test.mc";
+let user = null;
+
+let project = null;
+let experiment_number = 0;
+
+let random_project_name = function(){
     let number = Math.floor(Math.random()*10000);
-    return base_project_name + number;
+    return "Project For Process Testing - " + number;
 };
-
-let random_user = function(){
-    let number = Math.floor(Math.random()*10000);
-    return base_user_id + number + "@mc.org";
-};
-
-let user1Id = random_user();
 
 before(function*() {
-    let user = yield dbModelUsers.getUser(user1Id);
-    if (!user) {
-        let results = yield r.table('users').insert({
-            admin: false,
-            affiliation: "",
-            avatar: "",
-            description: "",
-            email: user1Id,
-            fullname: fullname,
-            homepage: "",
-            id: user1Id,
-            name: fullname,
-            preferences: {
-                tags: [],
-                templates: []
-            }
-        });
-        assert.equal(results.inserted, 1, "The User was correctly inserted");
-    } else {
-        assert.equal(user.id,user1Id, "Wrong test user, id = " + user.id);
-    }
+    user = yield dbModelUsers.getUser(userId);
+    assert.isOk(user, "No test user available = " + userId);
+    assert.equal(userId, user.id);
+    let ret = yield testHelpers.createProject(random_project_name(),user);
+    assert.isOk(ret);
+    assert.isOk(ret.val);
+    project = ret.val;
+    assert.equal(project.owner,user.id);
+    console.log("Test project name: ",project.name);
 });
 
 describe('Feature - Processes: ', function() {
     describe('Function level', function () {
-        it('individual test level');
+        it('creates a process', function*(){
+            let ret = yield testHelpers.createExperiment(project,"Create Process Experiment");
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let experiment = ret.val;
+            assert.isOk(experiment);
+            assert.equal(experiment.owner,user.id);
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_Create Samples');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let process = ret.val;
+            assert.isOk(process);
+            assert.equal(process.owner,user.id);
+        });
+        it('creates two processes linked by sample ', function*(){
+            let ret = yield testHelpers.createExperiment(project,"Two Processes Experiment");
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let experiment = ret.val;
+            assert.isOk(experiment);
+            assert.equal(experiment.owner,user.id);
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_Create Samples');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let create_sample_process = ret.val;
+            assert.isOk(create_sample_process);
+            assert.equal(create_sample_process.owner,user.id);
+            ret = yield testHelpers.createSamples(
+                project, experiment, create_sample_process, ['Test Sample']
+            );
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            assert.isOk(ret.val.samples);
+            assert.equal(ret.val.samples.length,1);
+            let sample = samples[0];
+            console.log(sample);
+        });
+
     });
 });
-
-after(function*() {
-    let user = yield dbModelUsers.getUser(user1Id);
-    if (user) {
-        let results = yield r.table('users').get(user1Id).delete();
-        assert.equal(results.deleted,1, "The User was correctly deleted");
-    } else {
-        assert.isNull(user,"The user still exists at end");
-    }
-});
-

--- a/backend/tests/mcapi/Database-Level/specs/processes-spec.js
+++ b/backend/tests/mcapi/Database-Level/specs/processes-spec.js
@@ -15,6 +15,7 @@ const mcapi_base = '../../../../servers/mcapi';
 const backend_base = mcapi_base + "/db/model";
 
 const dbModelUsers = require(backend_base + '/users');
+const processes = require(backend_base + '/processes');
 
 const testHelpers = require('./test-helpers');
 
@@ -79,9 +80,104 @@ describe('Feature - Processes: ', function() {
             assert.isOk(ret.val);
             assert.isOk(ret.val.samples);
             assert.equal(ret.val.samples.length,1);
-            let sample = samples[0];
-            console.log(sample);
+            let sample = ret.val.samples[0];
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_SEM');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let measurement_process = ret.val;
+            assert.isOk(measurement_process);
+            assert.equal(measurement_process.owner,user.id);
+            ret = yield testHelpers.addSamplesToProcess(
+                project, experiment, measurement_process, [sample]
+            );
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            assert.equal(ret.val.owner,user.id);
+            assert.equal(ret.val.id,measurement_process.id);
         });
-
+        it('deletes two processes leaf first', function*(){
+            let ret = yield testHelpers.createExperiment(project,"Two Processes Delete Experiment");
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let experiment = ret.val;
+            assert.isOk(experiment);
+            assert.equal(experiment.owner,user.id);
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_Create Samples');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let create_sample_process = ret.val;
+            assert.isOk(create_sample_process);
+            assert.equal(create_sample_process.owner,user.id);
+            ret = yield testHelpers.createSamples(
+                project, experiment, create_sample_process, ['Test Sample']
+            );
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            assert.isOk(ret.val.samples);
+            assert.equal(ret.val.samples.length,1);
+            let sample = ret.val.samples[0];
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_SEM');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let measurement_process = ret.val;
+            assert.isOk(measurement_process);
+            assert.equal(measurement_process.owner,user.id);
+            ret = yield testHelpers.addSamplesToProcess(
+                project, experiment, measurement_process, [sample]
+            );
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            assert.equal(ret.val.owner,user.id);
+            assert.equal(ret.val.id,measurement_process.id);
+            ret = yield processes.deleteProcess(project.id, measurement_process.id);
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            ret = yield processes.deleteProcess(project.id, create_sample_process.id);
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+        });
+        it('does not allow deleting non-leaf nodes', function*(){
+            let ret = yield testHelpers.createExperiment(project,"Two Processes Delete Experiment");
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let experiment = ret.val;
+            assert.isOk(experiment);
+            assert.equal(experiment.owner,user.id);
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_Create Samples');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let create_sample_process = ret.val;
+            assert.isOk(create_sample_process);
+            assert.equal(create_sample_process.owner,user.id);
+            ret = yield testHelpers.createSamples(
+                project, experiment, create_sample_process, ['Test Sample']
+            );
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            assert.isOk(ret.val.samples);
+            assert.equal(ret.val.samples.length,1);
+            let sample = ret.val.samples[0];
+            ret = yield testHelpers.createProcess(
+                project, experiment, "Test Create Sample Process",'global_SEM');
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            let measurement_process = ret.val;
+            assert.isOk(measurement_process);
+            assert.equal(measurement_process.owner,user.id);
+            ret = yield testHelpers.addSamplesToProcess(
+                project, experiment, measurement_process, [sample]
+            );
+            assert.isOk(ret);
+            assert.isOk(ret.val);
+            assert.equal(ret.val.owner,user.id);
+            assert.equal(ret.val.id,measurement_process.id);
+            ret = yield processes.deleteProcess(project.id, create_sample_process.id);
+            assert.isOk(ret);
+            assert.isOk(ret.error);
+        });
     });
 });


### PR DESCRIPTION
Fixes delete process code to test for and block two cases; you can not delete a process that is:
1) included in a dataset, or 
2) not a leaf node in its workflow